### PR TITLE
add a note about the use of the switchbuf configuration option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,12 @@ Usage: map `switchy#switch()` to something, for example:
 The first function argument is the command to use when editing a file (e.g.
 `edit`, `split`, `tabedit`, `sbuf`, etc.), the second argument is the command to
 use when the buffer is already loaded. This is useful to switch to an existing
-split/tab instead of opening a new one.
+split/tab instead of opening a new one. Please note that you must have
+'switchbuf' set in your .vimrc to either 'useopen' or 'usetab' for switchy to 
+switch to an already open window or tab. Otherwise it will create a new window.
+E.g.:
+
+set switchbuf=usetab
 
 You can add your own callbacks with `switchy#add()`; see
 [ftplugin/go.vim](ftplugin/go.vim) for an example.


### PR DESCRIPTION
May save some people some time.  I spent about 30-45 minutes trying to figure out why, after opening the other file, when I switched back it would open yet another window.  Turns out the default value for 'switchbuf' is ''.  